### PR TITLE
Removed placeholders and improved wording

### DIFF
--- a/dIM/Views/Home/SettingsView/SettingsDetailView/AboutView.swift
+++ b/dIM/Views/Home/SettingsView/SettingsDetailView/AboutView.swift
@@ -45,10 +45,10 @@ struct AboutView: View {
         VStack {
             VStack {
                 FeatureCell(image: Image("appiconsvg"), title: "About dIM", subtitle: "dIM is a decentralized chat app based on Bluetooth.")
-                FeatureCell(image: Image(systemName: "network"), title: "Peer-to-peer network", subtitle: "When you send a message to someone, it will go through a peer-to-peer Bluetooth network made of other dIM users.")
+                FeatureCell(image: Image(systemName: "network"), title: "Peer-to-peer network", subtitle: "When you send a message to someone, it will go through a peer-to-peer Bluetooth network made up of other dIM users.")
                 FeatureCell(image: Image(systemName: "chevron.left.forwardslash.chevron.right"), title: "Open-Source", subtitle: "The source code of dIM is available to developers to help them improve their apps and dIM. It also raises trust into dIM security. [Visit dIM's GitHub repository...](https://github.com/KaffeDiem/dIM)")
                 FeatureCell(image: Image(systemName: "lock.circle"), title: "Encrypted and private", subtitle: "Messages are encrypted so that only you and the receiver can read them, protecting you from prying eyes.")
-                FeatureCell(image: Image(systemName: "bubble.left.and.bubble.right"), title: "Feedback is welcome", subtitle: "You can reach out to us by [sending us an email](mailto:support@dimchat.org?subject=dIM%20Support%20or%20Feedback) or [visiting out website](https://www.dimchat.org).")
+                FeatureCell(image: Image(systemName: "bubble.left.and.bubble.right"), title: "Feedback is welcome", subtitle: "You can reach out to us by [sending us an email](mailto:support@dimchat.org?subject=dIM%20Support%20or%20Feedback) or [visiting our website](https://www.dimchat.org).")
             }
             .padding()
             .navigationTitle("Decentralized Instant Messenger")


### PR DESCRIPTION
Found a google.com placeholder in the Markdown link for the dIM repository in the About page. Fixed that, and also improved some wording.